### PR TITLE
依存更新を Renovate から Dependabot へ移行

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,15 @@
+# yaml-language-server: $schema=https://json.schemastore.org/dependabot-2.0.json
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    labels:
+      - 'dependencies'
+  - package-ecosystem: 'nix'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+    labels:
+      - 'dependencies'

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,0 @@
-{
-  $schema: "https://docs.renovatebot.com/renovate-schema.json",
-  extends: ["config:best-practices"],
-  labels: ["dependencies"],
-  automerge: true,
-}

--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+name: 'Dependabot auto-merge'
+
+on: 'pull_request'
+
+permissions: {}
+
+jobs:
+  dependabot:
+    runs-on: 'ubuntu-24.04'
+    if: |
+      github.event.pull_request.user.login == 'dependabot[bot]'
+    permissions:
+      contents: 'write'
+      pull-requests: 'write'
+    timeout-minutes: 5
+    steps:
+      - id: 'metadata'
+        uses: 'dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98' # v3.1.0
+      - if: |
+          steps.metadata.outputs.update-type != 'version-update:semver-major'
+        run: |
+          gh pr merge --auto --merge "${PR_URL}"
+        env:
+          PR_URL: '${{ github.event.pull_request.html_url }}'
+          GH_TOKEN: '${{ secrets.GITHUB_TOKEN }}'


### PR DESCRIPTION
### 概要

zenn-contents の依存更新の管理方法を Renovate から Dependabot へ移行する。
姉妹リポジトリの op-aws-credential-process が同様の移行を完了しているため、管理方法を統一する。

### 背景

Renovate と Dependabot が別々のリポジトリで使い分けられている状態になっており、依存更新の運用方法をリポジトリ間で揃える必要があった。
op-aws-credential-process では 2026-07 に Renovate から Dependabot へ移行済み。

### 目的

依存更新の管理方法をリポジトリ間で統一する。

### 実装内容

- `.github/dependabot.yaml` を追加し、github-actions と nix の 2 エコシステムを weekly で更新対象にする
- `.github/renovate.json5` を削除する
- Dependabot 自体には自動マージ機能がないため、既存の `automerge: true` と同等の挙動を維持する `dependabot-automerge` ワークフローを追加する
